### PR TITLE
fix: remove RTD JS injection to restore mkdocs nav

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,23 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  jobs:
+    post_build:
+      # Remove RTD's JavaScript injection to prevent conflicts with mkdocs-material theme
+      - python -c "
+import os, re
+out = os.environ['READTHEDOCS_OUTPUT']
+for root, dirs, files in os.walk(os.path.join(out, 'html')):
+    for f in files:
+        if f.endswith('.html'):
+            p = os.path.join(root, f)
+            with open(p) as fh:
+                c = fh.read()
+            c = re.sub(r'<script[^>]*readthedocs[^>]*></script>', '', c)
+            c = re.sub(r'<link[^>]*readthedocs[^>]*>', '', c)
+            with open(p, 'w') as fh:
+                fh.write(c)
+"
 
 mkdocs:
   configuration: apps/rlark/mkdocs.yml


### PR DESCRIPTION
## Problem

The RTD documentation was missing the left navigation sidebar because Read the Docs injects its own JavaScript into the built HTML, which conflicts with the mkdocs-material theme's navigation initialization.

## Fix

Added a post-build step in `.readthedocs.yaml` to remove RTD's injected script and link tags from all HTML files after the mkdocs build completes.

This restores the mkdocs-material theme's full navigation sidebar, dark/light mode toggle, and other theme features.