### PR TITLE
fix: use external script for RTD injection removal

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,21 +6,7 @@ build:
     python: "3.12"
   jobs:
     post_build:
-      # Remove RTD's JavaScript injection to prevent conflicts with mkdocs-material theme
-      - python -c "
-import os, re
-out = os.environ['READTHEDOCS_OUTPUT']
-for root, dirs, files in os.walk(os.path.join(out, 'html')):
-    for f in files:
-        if f.endswith('.html'):
-            p = os.path.join(root, f)
-            with open(p) as fh:
-                c = fh.read()
-            c = re.sub(r'<script[^>]*readthedocs[^>]*></script>', '', c)
-            c = re.sub(r'<link[^>]*readthedocs[^>]*>', '', c)
-            with open(p, 'w') as fh:
-                fh.write(c)
-"
+      - python apps/rlark/docs/scripts/remove_rtd_injection.py
 
 mkdocs:
   configuration: apps/rlark/mkdocs.yml

--- a/apps/rlark/docs/scripts/remove_rtd_injection.py
+++ b/apps/rlark/docs/scripts/remove_rtd_injection.py
@@ -1,0 +1,26 @@
+"""Remove RTD's JavaScript injection from built HTML pages.
+
+Read the Docs injects its own JavaScript and CSS into the built HTML files,
+which conflicts with the mkdocs-material theme (navigation sidebar, dark/light
+mode toggle, etc.). This script removes those injected elements.
+"""
+
+import os
+import re
+
+output_dir = os.environ.get("READTHEDOCS_OUTPUT", "site")
+html_dir = os.path.join(output_dir, "html")
+
+for root, dirs, files in os.walk(html_dir):
+    for f in files:
+        if f.endswith(".html"):
+            path = os.path.join(root, f)
+            with open(path) as fh:
+                content = fh.read()
+            # Remove RTD's injected script and link tags
+            content = re.sub(
+                r'<script[^>]*readthedocs[^>]*></script>', "", content
+            )
+            content = re.sub(r'<link[^>]*readthedocs[^>]*>', "", content)
+            with open(path, "w") as fh:
+                fh.write(content)


### PR DESCRIPTION
## Problem

The previous `.readthedocs.yaml` used inline multi-line Python code in the `post_build` job, which caused a YAML parsing error:

```
YAML: while scanning a simple key
  could not find expected ':'
```

## Fix

- Moved the RTD injection removal logic to a standalone Python script: `apps/rlark/docs/scripts/remove_rtd_injection.py`
- Updated `.readthedocs.yaml` to call the script instead of inline code
- Verified locally: `mkdocs build` succeeds and the script runs without errors